### PR TITLE
add render mode and clipping to Camera module

### DIFF
--- a/src/simulation/sensors/camera/camera.cpp
+++ b/src/simulation/sensors/camera/camera.cpp
@@ -330,6 +330,9 @@ void Camera::UpdateState(uint64_t currentSimNanos)
     cameraMsg.ppFocalLength = this->ppFocalLength;
     cameraMsg.ppFocusDistance = this->ppFocusDistance;
     cameraMsg.ppMaxBlurSize = this->ppMaxBlurSize;
+    cameraMsg.renderMode = this->renderMode;
+    cameraMsg.depthMapClippingPlanes[0] = this->depthMapClippingPlanes[0];
+    cameraMsg.depthMapClippingPlanes[1] = this->depthMapClippingPlanes[1];
 
     /*! - Update the camera config data no matter if an image is present*/
     this->cameraConfigOutMsg.write(&cameraMsg, this->moduleID, currentSimNanos);

--- a/src/simulation/sensors/camera/camera.h
+++ b/src/simulation/sensors/camera/camera.h
@@ -86,6 +86,10 @@ public:
     Eigen::Vector3d hsv{Eigen::Vector3d::Zero()};    //!< (double) HSV color correction, H (-pi/pi) hue shift, S and V are percent multipliers
     Eigen::Vector3d bgrPercent{Eigen::Vector3d::Zero()}; //!< (int) BGR color correction values as percent
 
+     /* Depth parameters */
+    int renderMode; //!< (Optional) Value of 0 to render visual image (default), value of 1 to render depth buffer to image
+    double depthMapClippingPlanes[2]; //!< (Optional) [m] Set the bounds of rendered depth map by setting the near and far clipping planes when in renderMode=1 (depthMap mode). Default values of 0.1 and 100.
+
     BSKLogger bskLogger;                      //!< -- BSK Logging
 
 private:


### PR DESCRIPTION
## Description
Fixed issue with not being able to set Camera module as a depth sensor.

## Verification
Checked functionality using Vizard and passed existing unit tests.

## Documentation
No changes

## Future work
N/A
